### PR TITLE
fix: envars default to none will trigger error

### DIFF
--- a/snakemake_interface_executor_plugins/executors/real.py
+++ b/snakemake_interface_executor_plugins/executors/real.py
@@ -133,7 +133,7 @@ class RealExecutor(AbstractExecutor):
         if self.pass_envvar_declarations_to_cmd:
             return " ".join(
                 f"{var}={repr(os.environ[var])}"
-                for var in self.workflow.remote_execution_settings.envvars
+                for var in self.workflow.remote_execution_settings.envvars or {}
             )
         else:
             return ""

--- a/snakemake_interface_executor_plugins/jobs.py
+++ b/snakemake_interface_executor_plugins/jobs.py
@@ -85,11 +85,11 @@ class JobExecutorInterface(ABC):
     @abstractmethod
     def postprocess(
         self,
-        store_in_storage: bool=True,
-        handle_log: bool=True,
-        handle_touch: bool=True,
-        error: bool=False,
-        ignore_missing_output: bool=False,
+        store_in_storage: bool = True,
+        handle_log: bool = True,
+        handle_touch: bool = True,
+        error: bool = False,
+        ignore_missing_output: bool = False,
     ) -> None:
         ...
 


### PR DESCRIPTION
Problem: if a workflow does not have default envvars, the function get_envvar_declarations will error trying to iterate over a None object.

Solution: add an or {} to ensure that we do not error.