### PR TITLE
feat: add a default for the `can_transfer_local_files` interface

### DIFF
--- a/snakemake_interface_executor_plugins/settings.py
+++ b/snakemake_interface_executor_plugins/settings.py
@@ -53,6 +53,10 @@ class CommonSettings:
         of the user provided settings. This should be True if the executor spawns
         another non-local executor that runs jobs on the same node.
         For example, it is used in snakemake-executor-plugin-slurm-jobstep.
+    can_transfer_local_files: bool
+        Indicates whether the plugin can transfer local files to the remote executor when
+        run without a shared FS. If true, it's the plugin's responsibility and not
+        Snakemake's to manage file transfers.
     """
 
     non_local_exec: bool
@@ -68,6 +72,7 @@ class CommonSettings:
     init_seconds_before_status_checks: int = 0
     pass_group_args: bool = False
     spawned_jobs_assume_shared_fs: bool = False
+    can_transfer_local_files: bool = False
 
     @property
     def local_exec(self):


### PR DESCRIPTION
This PR corresponds to https://github.com/snakemake/snakemake/pull/2921 and adds a default value to the plugin interface for the `can_transfer_local_files` option. When true, snakemake assumes the plugin can manage its own file transfers in environments that don't provide a shared filesystem.