### PR TITLE
feat: load builtin snakemake executor plugins

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ version = "9.2.0"
 argparse-dataclass = "^2.0.0"
 python = "^3.11"
 throttler = "^1.2.2"
-snakemake-interface-common = "^1.12.0"
+snakemake-interface-common = "^1.17.4"
 
 [tool.poetry.dev-dependencies]
 black = "^24.0.0"

--- a/snakemake_interface_executor_plugins/registry/__init__.py
+++ b/snakemake_interface_executor_plugins/registry/__init__.py
@@ -57,3 +57,18 @@ class ExecutorPluginRegistry(PluginRegistryBase):
                 kind=AttributeKind.CLASS,
             ),
         }
+
+    def collect_plugins(self):
+        """Collect plugins and call register_plugin for each."""
+        super().collect_plugins()
+
+        try:
+            from snakemake.executors import local as local_executor
+            from snakemake.executors import dryrun as dryrun_executor
+            from snakemake.executors import touch as touch_executor
+        except ImportError:
+            # snakemake not present, proceed without adding these plugins
+            return
+
+        for executor in [local_executor, dryrun_executor, touch_executor]:
+            self.register_plugin(executor.__name__, executor)


### PR DESCRIPTION
This enables simpler code when loading the registry and wanting to also use Snakemake's internal executor plugins (local, dryrun, touch).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a method for collecting and registering plugins, enhancing plugin management capabilities.
  
- **Bug Fixes**
	- Improved error handling for missing dependencies, ensuring smoother operation when the `snakemake` package is not available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->