### PR TITLE
fix: problem with spaces in path (by quoting CLI args)

### DIFF
--- a/snakemake_interface_executor_plugins/utils.py
+++ b/snakemake_interface_executor_plugins/utils.py
@@ -42,10 +42,10 @@ def format_cli_pos_arg(value, quote=True, base64_encode: bool = False):
 
         return join_cli_args(fmt_item(key, val) for key, val in value.items())
     elif not_iterable(value):
-        return format_cli_value(value, base64_encode=base64_encode)
+        return format_cli_value(value, quote=quote, base64_encode=base64_encode)
     else:
         return join_cli_args(
-            format_cli_value(v, quote=True, base64_encode=base64_encode) for v in value
+            format_cli_value(v, quote=quote, base64_encode=base64_encode) for v in value
         )
 
 


### PR DESCRIPTION
Goes together with https://github.com/snakemake/snakemake/pull/3236
Fixes https://github.com/snakemake/snakemake/issues/3235

I don't know if adding quoting of CLI args by default will break anything&mdash;I didn't run the whole test suite locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of the `quote` parameter in CLI argument formatting for consistent behavior across single and iterable values. 

- **Chores**
	- Maintained existing functionality and error handling in related utility functions without introducing new changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->