### PR TITLE
fix: if requested, properly encode Path types as base64

### DIFF
--- a/snakemake_interface_executor_plugins/utils.py
+++ b/snakemake_interface_executor_plugins/utils.py
@@ -63,7 +63,10 @@ def format_cli_value(
     if isinstance(value, SettingsEnumBase):
         return value.item_to_choice()
     elif isinstance(value, Path):
-        return shlex.quote(str(value))
+        if base64_encode:
+            return encode_as_base64(str(value))
+        else:
+            return shlex.quote(str(value))
     elif isinstance(value, str):
         if is_quoted(value) and not base64_encode:
             # the value is already quoted, do not quote again


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced command-line value processing: file path values now support optional Base64 encoding when enabled, while maintaining the original behavior otherwise. This update improves how path inputs are handled during command execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->