### PR TITLE
fix: do not constrain resources in remote jobs

### DIFF
--- a/snakemake_interface_executor_plugins/executors/real.py
+++ b/snakemake_interface_executor_plugins/executors/real.py
@@ -103,7 +103,6 @@ class RealExecutor(AbstractExecutor):
                     unneeded_temp_files,
                     skip=not unneeded_temp_files,
                 ),
-                self.get_resource_declarations(job),
             ]
         )
 


### PR DESCRIPTION
Previously, the jobs resource usage was used to define global resource constraints for the remote job. This is (a) not necessary, since the remote job comes with its own resources anyway, and (b) can cause errors in case of pipe groups, where the consuming job does not yet have e.g. a defined memory usage if the memory is determined at runtime, such that it cannot be considered when calculating the resource constraints for the remote job.