### PR TITLE
refactor!: executor settings moved into direct attribute of the executor base class; change deployment_method type into str

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ class Executor(RemoteExecutor):
         # access workflow
         self.workflow
         # access executor specific settings
-        self.workflow.executor_settings
+        self.executor_settings
 
         # IMPORTANT: in your plugin, only access methods and properties of
         # Snakemake objects (like Workflow, Persistence, etc.) that are

--- a/snakemake_interface_executor_plugins/executors/base.py
+++ b/snakemake_interface_executor_plugins/executors/base.py
@@ -9,6 +9,7 @@ from typing import Any, Dict, List, Optional
 
 from snakemake_interface_executor_plugins.jobs import JobExecutorInterface
 from snakemake_interface_executor_plugins.logging import LoggerExecutorInterface
+from snakemake_interface_executor_plugins.settings import ExecutorSettingsBase
 from snakemake_interface_executor_plugins.utils import format_cli_arg
 from snakemake_interface_executor_plugins.workflow import WorkflowExecutorInterface
 
@@ -25,9 +26,11 @@ class AbstractExecutor(ABC):
         self,
         workflow: WorkflowExecutorInterface,
         logger: LoggerExecutorInterface,
+        executor_settings: Optional[ExecutorSettingsBase],
     ):
         self.workflow = workflow
         self.dag = workflow.dag
+        self.executor_settings = executor_settings
         self.logger = logger
 
     def get_resource_declarations_dict(self, job: JobExecutorInterface):

--- a/snakemake_interface_executor_plugins/executors/real.py
+++ b/snakemake_interface_executor_plugins/executors/real.py
@@ -4,7 +4,7 @@ __email__ = "johannes.koester@uni-due.de"
 __license__ = "MIT"
 
 from abc import abstractmethod
-from typing import Dict
+from typing import Dict, Optional
 
 from snakemake_interface_common import at_least_snakemake_version
 from snakemake_interface_executor_plugins.executors.base import (
@@ -12,7 +12,7 @@ from snakemake_interface_executor_plugins.executors.base import (
     SubmittedJobInfo,
 )
 from snakemake_interface_executor_plugins.logging import LoggerExecutorInterface
-from snakemake_interface_executor_plugins.settings import ExecMode
+from snakemake_interface_executor_plugins.settings import ExecMode, ExecutorSettingsBase
 from snakemake_interface_executor_plugins.utils import (
     encode_target_jobs_cli_args,
     format_cli_arg,
@@ -27,13 +27,15 @@ class RealExecutor(AbstractExecutor):
         self,
         workflow: WorkflowExecutorInterface,
         logger: LoggerExecutorInterface,
+        executor_settings: Optional[ExecutorSettingsBase],
         post_init: bool = True,
     ):
         super().__init__(
             workflow,
             logger,
+            executor_settings,
         )
-        self.executor_settings = self.workflow.executor_settings
+        self.executor_settings = executor_settings
         self.snakefile = workflow.main_snakefile
         if post_init:
             self.__post_init__()

--- a/snakemake_interface_executor_plugins/settings.py
+++ b/snakemake_interface_executor_plugins/settings.py
@@ -176,16 +176,10 @@ class StorageSettingsExecutorInterface(ABC):
         )
 
 
-class DeploymentMethod(SettingsEnumBase):
-    CONDA = 0
-    APPTAINER = 1
-    ENV_MODULES = 2
-
-
 class DeploymentSettingsExecutorInterface(ABC):
     @property
     @abstractmethod
-    def deployment_method(self) -> Set[DeploymentMethod]: ...
+    def deployment_method(self) -> Set[str]: ...
 
 
 class GroupSettingsExecutorInterface(ABC):

--- a/snakemake_interface_executor_plugins/settings.py
+++ b/snakemake_interface_executor_plugins/settings.py
@@ -142,6 +142,7 @@ class SharedFSUsage(SettingsEnumBase):
     SOURCES = 3
     STORAGE_LOCAL_COPIES = 4
     SOURCE_CACHE = 5
+    SOFTWARE_DEPLOYMENT_CACHE = 6
 
     @classmethod
     def choices(cls) -> List[str]:

--- a/snakemake_interface_executor_plugins/workflow.py
+++ b/snakemake_interface_executor_plugins/workflow.py
@@ -9,6 +9,7 @@ from typing import Optional
 from snakemake_interface_executor_plugins.cli import (
     SpawnedJobArgsFactoryExecutorInterface,
 )
+from snakemake_interface_executor_plugins.dag import DAGExecutorInterface
 from snakemake_interface_executor_plugins.persistence import (
     PersistenceExecutorInterface,
 )
@@ -25,6 +26,10 @@ from snakemake_interface_executor_plugins.settings import (
 
 
 class WorkflowExecutorInterface(ABC):
+    @property
+    @abstractmethod
+    def dag(self) -> DAGExecutorInterface: ...
+
     @property
     @abstractmethod
     def spawned_job_args_factory(self) -> SpawnedJobArgsFactoryExecutorInterface: ...


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Executors can accept explicit executor settings; workflow exposes a read-only DAG property; improved CLI job-argument construction.

- Refactor
  - Executor initialization now accepts settings directly and includes a post-initialization hook.

- Documentation
  - README example updated to use the new executor settings access pattern.

- Breaking Changes
  - Deployment methods now use string identifiers instead of the previous enum.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->